### PR TITLE
add ale_aos8_show_vlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - aos8 - show command-log
 - aos8 - show microcode
 - aos8 - show system
+- aos8 - show vlan by @BennyE
+
+### New contributors
+
+- @BennyE first contribution [https://github.com/jefvantongerloo/textfsm-aos/pull/7](https://github.com/jefvantongerloo/textfsm-aos/pull/7)
 
 ## [0.1.0] - 2022-02-23
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ parsed result
 | show snmp station              | :heavy_check_mark: |        :x:         |
 | show snmp community map        | :heavy_check_mark: |        :x:         |
 | show system                    | :heavy_check_mark: | :heavy_check_mark: |
-| show vlan                      | :heavy_check_mark: |        :x:         |
+| show vlan                      | :heavy_check_mark: | :heavy_check_mark: |
 | show vlan port mobile          | :heavy_check_mark: |        :x:         |
 
 ## Direct TextFSM example usage

--- a/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.txt
+++ b/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.txt
@@ -1,0 +1,13 @@
+ vlan    type   admin   oper    ip    mtu          name
+------+-------+-------+------+------+------+------------------
+1      std       Ena     Ena   Dis    1500    VLAN 1                          
+2      std       Ena     Ena   Ena    1500    192.168.2.x/24 Server           
+10     std       Ena     Ena   Ena    1500    192.168.10.x/24 Stellar OV      
+11     std       Ena     Ena   Ena    1500    192.168.11.x/24                 
+12     std       Ena     Ena   Ena    1500    192.168.12.x/24                 
+13     std       Ena     Ena   Ena    1500    192.168.13.x/24                 
+14     std       Ena     Ena   Ena    1500    192.168.14.x/24                 
+15     std       Ena     Ena   Ena    1500    192.168.15.x/24 Stellar Express 
+20     std       Ena     Ena   Dis    1500    VLAN 20                         
+4094   vcm       Ena     Dis   Dis    1500    VCM IPC                         
+

--- a/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.yml
+++ b/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.yml
@@ -1,70 +1,70 @@
 - vlannumber: '1'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Dis
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Dis'
   vlanmtu: '1500'
-  vlandescription: VLAN 1
+  vlandescription: 'VLAN 1'
 - vlannumber: '2'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.2.x/24 Server
+  vlandescription: '192.168.2.x/24 Server'
 - vlannumber: '10'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.10.x/24 Stellar OV
+  vlandescription: '192.168.10.x/24 Stellar OV'
 - vlannumber: '11'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.11.x/24
+  vlandescription: '192.168.11.x/24'
 - vlannumber: '12'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.12.x/24
+  vlandescription: '192.168.12.x/24'
 - vlannumber: '13'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.13.x/24
+  vlandescription: '192.168.13.x/24'
 - vlannumber: '14'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.14.x/24
+  vlandescription: '192.168.14.x/24'
 - vlannumber: '15'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Ena
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Ena'
   vlanmtu: '1500'
-  vlandescription: 192.168.15.x/24 Stellar Express
+  vlandescription: '192.168.15.x/24 Stellar Express'
 - vlannumber: '20'
-  vlantype: std
-  vlanadmstatus: Ena
-  vlanoperstatus: Ena
-  vlanrouterstatus: Dis
+  vlantype: 'std'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Ena'
+  vlanrouterstatus: 'Dis'
   vlanmtu: '1500'
-  vlandescription: VLAN 20
+  vlandescription: 'VLAN 20'
 - vlannumber: '4094'
-  vlantype: vcm
-  vlanadmstatus: Ena
-  vlanoperstatus: Dis
-  vlanrouterstatus: Dis
+  vlantype: 'vcm'
+  vlanadmstatus: 'Ena'
+  vlanoperstatus: 'Dis'
+  vlanrouterstatus: 'Dis'
   vlanmtu: '1500'
-  vlandescription: VCM IPC
+  vlandescription: 'VCM IPC'

--- a/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.yml
+++ b/tests/ale_aos8_show_vlan/ale_aos8_show_vlan.yml
@@ -1,0 +1,70 @@
+- vlannumber: '1'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Dis
+  vlanmtu: '1500'
+  vlandescription: VLAN 1
+- vlannumber: '2'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.2.x/24 Server
+- vlannumber: '10'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.10.x/24 Stellar OV
+- vlannumber: '11'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.11.x/24
+- vlannumber: '12'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.12.x/24
+- vlannumber: '13'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.13.x/24
+- vlannumber: '14'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.14.x/24
+- vlannumber: '15'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Ena
+  vlanmtu: '1500'
+  vlandescription: 192.168.15.x/24 Stellar Express
+- vlannumber: '20'
+  vlantype: std
+  vlanadmstatus: Ena
+  vlanoperstatus: Ena
+  vlanrouterstatus: Dis
+  vlanmtu: '1500'
+  vlandescription: VLAN 20
+- vlannumber: '4094'
+  vlantype: vcm
+  vlanadmstatus: Ena
+  vlanoperstatus: Dis
+  vlanrouterstatus: Dis
+  vlanmtu: '1500'
+  vlandescription: VCM IPC

--- a/textfsm_aos/templates/ale_aos8_show_vlan.textfsm
+++ b/textfsm_aos/templates/ale_aos8_show_vlan.textfsm
@@ -1,0 +1,15 @@
+Value vlannumber (\d+)
+Value vlantype (std|vstk|router|mvrp|ipmv|pvlan-p|pvlan-c|pvlan-i|fcoe|vcm)
+Value vlanadmstatus (Ena|Dis)
+Value vlanoperstatus (Ena|Dis)
+Value vlanrouterstatus (Ena|Dis)
+Value vlanmtu (\d+)
+Value vlandescription ((\S+\s*)+\S+)
+
+Start
+  ^\s*vlan\s+type\s+admin\s+oper\s+ip\s+mtu\s+name\s$$
+  ^------\+-------\+-------\+------\+------\+------\+------------------$$ -> VLAN
+
+VLAN
+  ^\s*${vlannumber}\s+${vlantype}\s+${vlanadmstatus}\s+${vlanoperstatus}\s+${vlanrouterstatus}\s+${vlanmtu}\s+${vlandescription}\s*$$ -> Record
+  ^. -> Error

--- a/textfsm_aos/templates/templates_index.yml
+++ b/textfsm_aos/templates/templates_index.yml
@@ -45,5 +45,7 @@
   platform: ale_aos8
 - command: show vlan
   platform: ale_aos6
+- command: show vlan
+  platform: ale_aos8
 - command: show vlan port mobile
   platform: ale_aos6


### PR DESCRIPTION
Hi @jefvantongerloo,

Thanks for your great work on this! 👍 
I added "show vlan" for AOS R8.
I never worked with tox/pytest before, so I hope this was done correctly :)

Output for "tox":
```
_________________________________________________________________________ summary _________________________________________________________________________
  black: commands succeeded
  flake8: commands succeeded
  pylama: commands succeeded
  yamllint: commands succeeded
  congratulations :)
```

Output for pytest:
```
(.venv) benny@Bennys-MacBook-Pro textfsm-aos % pytest
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.8.9, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/benny/Python/textfsm-aos
collected 25 items                                                                                                                                        

tests/test_parsed_data.py .........................                                                                                                 [100%]

=================================================================== 25 passed in 0.25s ====================================================================
```

Thanks,
Regards,
Benny