### PR TITLE
Add ale_aos8_show_running-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,17 @@
 
 ### Added CLI commands
 
-- aos8 - show chassis
-- aos6 - show command-log
-- aos8 - show command-log
-- aos8 - show microcode
-- aos8 - show system
-- aos8 - show vlan by @BennyE
+- aos6 - show command-log [#5](https://github.com/jefvantongerloo/textfsm-aos/pull/5)
+- aos6 - show running-directory [#8](https://github.com/jefvantongerloo/textfsm-aos/pull/8) by [@BennyE](https://github.com/BennyE)
+- aos8 - show chassis [#6](https://github.com/jefvantongerloo/textfsm-aos/pull/6)
+- aos8 - show command-log [#4](https://github.com/jefvantongerloo/textfsm-aos/pull/4)
+- aos8 - show microcode [#2](https://github.com/jefvantongerloo/textfsm-aos/pull/2)
+- aos8 - show system [#3](https://github.com/jefvantongerloo/textfsm-aos/pull/3)
+- aos8 - show vlan [#7](https://github.com/jefvantongerloo/textfsm-aos/pull/7) by [@BennyE](https://github.com/BennyE)
 
 ### New contributors
 
-- @BennyE first contribution [https://github.com/jefvantongerloo/textfsm-aos/pull/7](https://github.com/jefvantongerloo/textfsm-aos/pull/7)
+- [@BennyE](https://github.com/BennyE) first contribution [https://github.com/jefvantongerloo/textfsm-aos/pull/7](https://github.com/jefvantongerloo/textfsm-aos/pull/7)
 
 ## [0.1.0] - 2022-02-23
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ parsed result
 | show microcode                 | :heavy_check_mark: | :heavy_check_mark: |
 | show ntp server status         | :heavy_check_mark: |        :x:         |
 | show user                      | :heavy_check_mark: |        :x:         |
+| show running-directory         |        :x:         | :heavy_check_mark: |
 | show snmp station              | :heavy_check_mark: |        :x:         |
 | show snmp community map        | :heavy_check_mark: |        :x:         |
 | show system                    | :heavy_check_mark: | :heavy_check_mark: |

--- a/tests/ale_aos8_show_running-directory/ale_aos8_show_running-directory.txt
+++ b/tests/ale_aos8_show_running-directory/ale_aos8_show_running-directory.txt
@@ -1,0 +1,10 @@
+
+CONFIGURATION STATUS
+  Running CMM              : MASTER-PRIMARY,
+  CMM Mode                 : VIRTUAL-CHASSIS MONO CMM,
+  Current CMM Slot         : CHASSIS-1 A,
+  Running configuration    : WORKING,
+  Certify/Restore Status   : CERTIFIED
+SYNCHRONIZATION STATUS
+  Running Configuration    : SYNCHRONIZED
+

--- a/tests/ale_aos8_show_running-directory/ale_aos8_show_running-directory.yml
+++ b/tests/ale_aos8_show_running-directory/ale_aos8_show_running-directory.yml
@@ -1,0 +1,9 @@
+---
+- running_cmm: 'MASTER-PRIMARY'
+  cmm_mode: 'VIRTUAL-CHASSIS MONO CMM'
+  current_cmm_slot: 'CHASSIS-1 A'
+  running_directory: 'WORKING'
+  certify_restore_status: 'CERTIFIED'
+  flash_between_cmms: ''
+  running_configuration_status: 'SYNCHRONIZED'
+  machine_state: ''

--- a/textfsm_aos/templates/ale_aos8_show_running-directory.textfsm
+++ b/textfsm_aos/templates/ale_aos8_show_running-directory.textfsm
@@ -1,0 +1,21 @@
+Value running_cmm (.+)
+Value cmm_mode (.+)
+Value current_cmm_slot (.+)
+Value running_directory (.+)
+Value certify_restore_status (.+)
+Value flash_between_cmms (.+)
+Value running_configuration_status (.+)
+Value machine_state (.+)
+
+Start
+  ^CONFIGURATION STATUS,
+  ^\s{2}Running CMM\s+:\s${running_cmm},
+  ^\s{2}CMM Mode\s+:\s${cmm_mode},
+  ^\s{2}Current CMM Slot\s+:\s${current_cmm_slot},
+  ^\s{2}Running configuration\s+:\s${running_directory},
+  ^\s{2}Certify/Restore Status\s+:\s${certify_restore_status}
+  ^SYNCHRONIZATION STATUS,
+  ^\s{2}Flash Between CMMs\s+:\s${flash_between_cmms} -> Continue
+  ^\s{2}Running Configuration\s+:\s${running_configuration_status}
+  ^BOOT STATUS, -> Continue
+  ^\s{2}Machine State\s+:\s${machine_state} -> Record Start

--- a/textfsm_aos/templates/templates_index.yml
+++ b/textfsm_aos/templates/templates_index.yml
@@ -35,6 +35,8 @@
   platform: ale_aos6
 - command: show user
   platform: ale_aos6
+- command: show running-directory
+  platform: ale_aos8
 - command: show snmp station
   platform: ale_aos6
 - command: show snmp community map


### PR DESCRIPTION
Adding "show running-directory" support for AOS Release 8.

I found that AOS R6 may have an additional line in output:
```
DUT-> show running-directory

CONFIGURATION STATUS

   Running CMM              : PRIMARY,
   CMM Mode                 : DUAL CMMs,
   Current CMM Slot         : 1,
   Running configuration    : WORKING,
   Certify/Restore Status   : CERTIFIED

SYNCHRONIZATION STATUS

   Flash Between CMMs       : SYNCHRONIZED,
   Running Configuration    : SYNCHRONIZED,
   Stacks Reload on Takeover: PRIMARY ONLY      # <- R6
```


Output of tox:
```
__________________________________________________________ summary __________________________________________________________
  black: commands succeeded
  flake8: commands succeeded
  pylama: commands succeeded
  yamllint: commands succeeded
  congratulations :)
```

Output of pytest:
```
(.venv) benny@Bennys-MacBook-Pro textfsm-aos % pytest
==================================================== test session starts ====================================================
platform darwin -- Python 3.8.9, pytest-7.0.1, pluggy-1.0.0
rootdir: /Users/benny/Python/textfsm-aos
collected 26 items                                                                                                          

tests/test_parsed_data.py ..........................                                                                  [100%]

==================================================== 26 passed in 0.26s =====================================================
```