### PR TITLE
Fix ale aos6 show mac address table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### fixed
 
+- aos6 - `show mac address-table` fix trailing spaces and empty protocol with `---` placeholder [#38](https://github.com/jefvantongerloo/textfsm-aos/pull/38)
 - aos8 - `show cmm` fix missing ',' at end of line on fpga parameters [#3](https://github.com/jefvantongerloo/textfsm-aos/pull/35)
 - aos8 - `show log events` catch space in time instead of '0', for example `2022 Apr  7 17: 8: 5.306` [#37](https://github.com/jefvantongerloo/textfsm-aos/pull/37)
 - aos8 - `show mac-learning` missing trailing whitespace in output causes parsing error [#5](https://github.com/jefvantongerloo/textfsm-aos/pull/5)

--- a/textfsm_aos/templates/ale_aos6_show_mac-address-table.textfsm
+++ b/textfsm_aos/templates/ale_aos6_show_mac-address-table.textfsm
@@ -1,7 +1,7 @@
 Value vlan (\d+)
 Value mac_address (([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]){2})
 Value type (learned|permanent)
-Value protocol (\S+)
+Value protocol (\S+|[-]+)
 Value operation (bridging|filtering)
 Value interface (\d/\d+)
 
@@ -11,6 +11,6 @@ Start
   ^\s+------\+-------------------\+--------------\+-----------\+------------\+-----------$$ -> Mac
 
 Mac
-  ^\s+${vlan}\s+${mac_address}\s+${type}\s+${protocol}\s+${operation}\s+${interface}$$ -> Record
+  ^\s+${vlan}\s+${mac_address}\s+${type}\s+${protocol}\s+${operation}\s+${interface}\s*$$ -> Record
   ^Total number of Valid MAC addresses above = \d+
   ^. -> Error


### PR DESCRIPTION
fix ale_aos6 `show mac-address-table` trailing spaces and empty protocol '---' placeholder