### PR TITLE
Fix ale aos8 show log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - aos8 - `show cmm` fix missing ',' at end of line on fpga parameters [#3](https://github.com/jefvantongerloo/textfsm-aos/pull/35)
 - aos8 - `show ip routes` fix whitespace between days and hours [#40](https://github.com/jefvantongerloo/textfsm-aos/pull/40)
 - aos8 - `show log events` catch space in time instead of '0', for example `2022 Apr  7 17: 8: 5.306` [#37](https://github.com/jefvantongerloo/textfsm-aos/pull/37)
+- aos8 - `show log events` ':' in log_description value for example `Authentication failure detected: user admin` [#43](https://github.com/jefvantongerloo/textfsm-aos/pull/43)
 - aos8 - `show mac-learning` missing trailing whitespace in output causes parsing error [#5](https://github.com/jefvantongerloo/textfsm-aos/pull/5)
 - aos8 - `show unp user` catch missing trailing whitespace [#36](https://github.com/jefvantongerloo/textfsm-aos/pull/36)
 - aos8 - `show snmp community-map` fix empty username field value [#38](https://github.com/jefvantongerloo/textfsm-aos/pull/38)

--- a/textfsm_aos/templates/ale_aos8_show_log_events.textfsm
+++ b/textfsm_aos/templates/ale_aos8_show_log_events.textfsm
@@ -1,7 +1,7 @@
 Value swlog_timestamp (\d+\s\w+\s+\d+\s+\d{1,2}:\s*\d{1,2}:\s*\d+.\d+)
 Value cmm_ni ([^:]*)
 Value module_name ([^:]*)
-Value log_description ([^:]*)
+Value log_description ([^:].*)
 
 Start
   ^${swlog_timestamp}\s+:\s${cmm_ni}\s:\s${module_name}\s:\s${log_description}$$ -> Record


### PR DESCRIPTION
fix ale_aos8 `show log events` for ':' character in log_description value