### PR TITLE
fix template empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Textfsm-aos release notes
 
+## [0.4.0] - Unreleased
+
+### Fixed
+
+- pytest - test `template_index_names`, fix empty list return [#44](https://github.com/jefvantongerloo/textfsm-aos/pull/44)
+
 ## [0.3.0] - 2022-04-11
 
 ### Added CLI commands
 
-- aos6 - `show 802.1x users unp` [#30](https://github.com/jefvantongerloo/textfsm-aos/pull/28)
+- aos6 - `show 802.1x users unp` [#30](https://github.com/jefvantongerloo/textfsm-aos/pull/30)
 - aos8 - `history` [#32](https://github.com/jefvantongerloo/textfsm-aos/pull/32) by [@BennyE](https://github.com/BennyE)
 - aos8 - `show health` [#24](https://github.com/jefvantongerloo/textfsm-aos/pull/24) by [@BennyE](https://github.com/BennyE)
 - aos8 - `show ip interface` [#20](https://github.com/jefvantongerloo/textfsm-aos/pull/20) by [@BennyE](https://github.com/BennyE)

--- a/tests/test_template_index_names.py
+++ b/tests/test_template_index_names.py
@@ -1,4 +1,3 @@
-import pytest
 import textfsm_aos
 from textfsm_aos import templates
 import importlib.resources as pkg_resources

--- a/tests/test_template_index_names.py
+++ b/tests/test_template_index_names.py
@@ -1,3 +1,4 @@
+import pytest
 import textfsm_aos
 from textfsm_aos import templates
 import importlib.resources as pkg_resources
@@ -9,9 +10,9 @@ def test_template_index_names():
     template_files = pkg_resources.contents(templates)
     template_index = textfsm_aos.parser._get_template_index()
 
-    for template in template_files:
-        if template.find("ale_") != -1:
-            template_files_ale.append(template.split(".")[0])
+    template_files_ale = [
+        template for template in template_files if (template.find("ale_") != -1)
+    ]
 
     for template in template_index:
         template_index_ale.append(
@@ -21,4 +22,7 @@ def test_template_index_names():
             + ".textfsm"
         )
 
-    assert template_index_ale.sort() == template_files_ale.sort()
+    template_files_ale.sort()
+    template_index_ale.sort()
+
+    assert template_index_ale == template_files_ale


### PR DESCRIPTION
Fix test `template_index_names` empty list return.