### PR TITLE
fix missing space in age parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Textfsm-aos release notes
 
+## [1.0.1] - Unreleased
+
+### Fixed
+
+- aos6 - `show ip route` [#50] (https://github.com/jefvantongerloo/textfsm-aos/pull/50)
+
 ## [1.0.0] - 2022-05-12
 
 ### Added CLI commands

--- a/textfsm_aos/templates/ale_aos6_show_ip_route.textfsm
+++ b/textfsm_aos/templates/ale_aos6_show_ip_route.textfsm
@@ -1,7 +1,7 @@
 Value dest_address ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
 Value subnet_mask ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
 Value gateway_address ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
-Value age ((\d+:\d+:\d+)|(\d+d\s\d+h))
+Value age ((\d+:\d+:\d+)|(\d+d\s*\d+h))
 Value protocol (\w+)
 
 Start


### PR DESCRIPTION
fix missing spage in `show ip route` age parameter:

```
+ = Equal cost multipath routes
 Total 3 routes

  Dest Address      Subnet Mask       Gateway Addr      Age       Protocol 
------------------+-----------------+-----------------+---------+-----------
  0.0.0.0           0.0.0.0           10.21.99.1         427d 0h  NETMGMT
  10.10.10.0        255.255.255.0     10.21.99.11        427d 0h  LOCAL
  127.0.0.1         255.255.255.255   127.0.0.1          616d16h  LOCAL
```