### PR TITLE
Bugfix textfsm broken release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Textfsm-aos release notes
 
+## [1.1.1] - 07-07-2022
+
+### Fixed
+
+- textfsm package release 1.1.3 is broken, due to missing wheel in distribution. [GitHub textfsm issue](https://github.com/google/textfsm/issues/105)
+
 ## [1.1.0] - 28-06-2022
 
 ### Added CLI commands

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,7 +207,7 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "virtualenv"
-version = "20.14.1"
+version = "20.15.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -226,7 +226,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "0234734655a0143ea0025693ab2ca06d1d835d54657d8199c34631d21bb1f2ee"
+content-hash = "9862b2a296d24029b656b5b8eed2a6b7ae1d8d1721c8799f000ca239d2b8dcba"
 
 [metadata.files]
 atomicwrites = [
@@ -336,6 +336,6 @@ tox = [
     {file = "tox-3.25.1.tar.gz", hash = "sha256:c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
-    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+    {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},
+    {file = "virtualenv-20.15.1.tar.gz", hash = "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "textfsm_aos"
-version = "1.1.0"
+version = "1.1.1"
 description = "Alcatel-Lucent Enterprise AOS CLI parsing (TextFSM)"
 authors = ["Jef Vantongerloo <jefvantongerloo@gmail.com>"]
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["network automation", "textfsm", "scraping", "Alcatel-Lucent Enterpr
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-textfsm = "^1.1.2"
+textfsm = "1.1.2"
 PyYAML = "^6.0"
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_parsed_data.py
+++ b/tests/test_parsed_data.py
@@ -11,6 +11,7 @@ def _get_raw(platform: str, command: str) -> str:
     with open(
         "tests/" + platform + "_" + command + "/" + platform + "_" + command + ".txt",
         "r",
+        encoding="utf-8",
     ) as structured:
         raw = structured.read()
     return raw
@@ -23,6 +24,7 @@ def _get_benchmark(platform: str, command: str) -> dict:
     with open(
         "tests/" + platform + "_" + command + "/" + platform + "_" + command + ".yml",
         "r",
+        encoding="utf-8",
     ) as structured:
         benchmark_parsed = yaml.safe_load(structured.read())
     return benchmark_parsed
@@ -37,7 +39,7 @@ def test_parsed_data(template: dict):
     )
     benchmark_data = _get_benchmark(template["platform"], template["command"])
 
-    print("Parsed data: \n {0} \n".format(parsed_data))
-    print("Benchmark data: \n {0} \n".format(benchmark_data))
+    print(f"Parsed data: \n {parsed_data} \n")
+    print(f"Benchmark data: \n {benchmark_data} \n")
 
     assert parsed_data == benchmark_data

--- a/tests/test_template_index_count.py
+++ b/tests/test_template_index_count.py
@@ -1,9 +1,13 @@
+"""Pytests for TextFSM_aos project."""
+
+import importlib.resources as pkg_resources
 import textfsm_aos
 from textfsm_aos import templates
-import importlib.resources as pkg_resources
 
 
 def test_template_index_count():
+    """Check template index count"""
+
     len_template_files = 0
 
     template_index = textfsm_aos.parser._get_template_index()

--- a/tests/test_template_index_names.py
+++ b/tests/test_template_index_names.py
@@ -1,9 +1,13 @@
+"""Pytests for TextFSM_aos project."""
+
+import importlib.resources as pkg_resources
 import textfsm_aos
 from textfsm_aos import templates
-import importlib.resources as pkg_resources
 
 
 def test_template_index_names():
+    """Check index names"""
+
     template_files_ale = []
     template_index_ale = []
     template_files = pkg_resources.contents(templates)

--- a/textfsm_aos/__init__.py
+++ b/textfsm_aos/__init__.py
@@ -1,5 +1,5 @@
 """Textfsm_aos - Parse scli output and return structured data."""
 from textfsm_aos import parser  # noqa
 
-__version__ = "0.1.0"
+__version__ = "1.1.1"
 __author__ = "Jef Vantongerloo"

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,12 @@ commands = pylama  textfsm_aos tests
 
 [testenv:yamllint]
 deps = yamllint
-commands = yamllint tests
+commands = yamllint textfsm_aos tests
 
 [testenv:pylint]
-deps = pylint
-commands = pylint textfsm_aos
+deps = 
+        poetry
+        pylint
+commands = 
+            poetry install
+            pylint --disable=W0212 textfsm_aos tests


### PR DESCRIPTION
Textfsm release 1.1.3 is broken due to missing wheel.
Set fixed textfsm version to 1.1.2 instead of latest minor release.