### PR TITLE
Fix travis import error split env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ stages:
 language: python
 
 python:
-    - "3.8"
+    - "3.9"
 
 # before_install:
 #     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ jobs:
         - stage: "lint"
           install:
             - pip install tox-travis
+            - pip install tox==3.28.0
           script:
             - tox -e ALL
         - stage: "pytest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.1.2] - Unreleased
 
+## Fixed
+
+- Travis ci/cd fails due tox-travis package incompatible with tox version 4.x. [#68](https://github.com/jefvantongerloo/textfsm-aos/pull/68)
+
 ## Changes
 
 - dependency updated and tested:


### PR DESCRIPTION
Travis ci/cd broken due to tox-travis package incompatible with tox version 4.x.
Fixed by forcing Tox version 3.28.0.
Related issue: [https://github.com/tox-dev/tox-travis/issues/159](https://github.com/tox-dev/tox-travis/issues/159)