### PR TITLE
Fix aos6 show command log 6.7.2.122.r08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ## Fixed
 
-- aos8 - `show microcode` [#70](https://github.com/jefvantongerloo/textfsm-aos/pull/70)
-- aos8 - `show cmm` [#69](https://github.com/jefvantongerloo/textfsm-aos/pull/69)
+- aos6 - `show command-log` fix `user` and `ipaddr` console value  [#71](https://github.com/jefvantongerloo/textfsm-aos/pull/71)
+- aos8 - `show microcode` fix `release` not correctly captured [#70](https://github.com/jefvantongerloo/textfsm-aos/pull/70)
+- aos8 - `show cmm` fix `fpga` not correctly captured [#69](https://github.com/jefvantongerloo/textfsm-aos/pull/69)
 - Travis ci/cd fails due tox-travis package incompatible with tox version 4.x. [#68](https://github.com/jefvantongerloo/textfsm-aos/pull/68)
 
 ## Changes

--- a/textfsm_aos/templates/ale_aos6_show_command-log.textfsm
+++ b/textfsm_aos/templates/ale_aos6_show_command-log.textfsm
@@ -1,12 +1,12 @@
 Value command (.+)
-Value username (.+)
+Value username (.*)
 Value date (.+)
-Value ipaddr ((?:[0-9]{1,3}\.){3}[0-9]{1,3})
+Value ipaddr (((?:[0-9]{1,3}\.){3}[0-9]{1,3})|console)
 Value result (SUCCESS|ERROR.+)
 
 Start
   ^Command\s+:\s+${command}\s*$$
-  ^\s+UserName\s+:\s+${username}\s*$$
+  ^\s+UserName\s:\s${username}\s*$$
   ^\s+Date\s+:\s+${date}\s+$$
   ^\s+Ip Addr\s+:\s+${ipaddr}\s*$$
   ^\s+Result\s+:\s+${result}\s*$$ -> Record Start


### PR DESCRIPTION
Fix integration test issue with `show command-log` aos firmware 6.7.2.122.R08.  
Refactored attribute user and ipaddr capture group.