### PR TITLE
Fix aos6 show 8021x users unp no clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Fixed
 
-- aos6 - `show command-log` fix `user` and `ipaddr` console value  [#71](https://github.com/jefvantongerloo/textfsm-aos/pull/71)
+- aos6 - `show 802.1x users` and `show 802.1x users unp` error on no clients [#71](https://github.com/jefvantongerloo/textfsm-aos/pull/71)
+- aos6 - `show command-log` fix `user` and `ipaddr` console value [#71](https://github.com/jefvantongerloo/textfsm-aos/pull/71)
 - aos8 - `show microcode` fix `release` not correctly captured [#70](https://github.com/jefvantongerloo/textfsm-aos/pull/70)
 - aos8 - `show cmm` fix `fpga` not correctly captured [#69](https://github.com/jefvantongerloo/textfsm-aos/pull/69)
 - Travis ci/cd fails due tox-travis package incompatible with tox version 4.x. [#68](https://github.com/jefvantongerloo/textfsm-aos/pull/68)

--- a/textfsm_aos/templates/ale_aos6_show_802.1x_users.textfsm
+++ b/textfsm_aos/templates/ale_aos6_show_802.1x_users.textfsm
@@ -13,5 +13,6 @@ Start
   ^[-+\+]+\s*$$ -> Users
 
 Users
+  ^System has no 802.1x client to show$$
   ^${slot_port}\s+${mac_address}\s+${port_state}\s+${classification_policy}\s+${auth_failure_reason}\s+${auth_retry_count}\s+${last_succesful_auth_time}\s+${user_name}$$ -> Record
   ^. -> Error

--- a/textfsm_aos/templates/ale_aos6_show_802.1x_users_unp.textfsm
+++ b/textfsm_aos/templates/ale_aos6_show_802.1x_users_unp.textfsm
@@ -11,5 +11,6 @@ Start
   ^[-+\+]+\s*$$ -> unp
 
 unp
+  ^System has no 802.1x client to show$$
   ^${slot}\s+${mac_address}\s+${vlan}\s+${hic_status}\s+${dynamic_unp}\s+${user_name} -> Record
   ^. -> Error


### PR DESCRIPTION
Fix integration test issue with `show command-log` aos firmware 6.7.2.122.R08.  
Error on no 802.1x clients to show message:
`System has no 802.1x client to show`
