### PR TITLE
Fix aos8 show vlan members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Textfsm-aos release notes
 
+## [1.1.3] - Unreleased
+
+- aos8 - `show vlan members`types `tagged`and `untagged`values missing [#72](https://github.com/jefvantongerloo/textfsm-aos/pull/72)
+
+## Fixed
+
 ## [1.1.2] - 20-22-2022
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ parsed result
 
 ## Integration tests
 
-| aos version                       |                    tests            | 
+| aos version                       |                    tests            |
 |-----------------------------------|:--------------------------------:|
 | 6.7.2.122.R08                  |    :heavy_check_mark:    |
+| 8.9.73.R01                       |    :heavy_check_mark:    |
 | 8.8.56.R02                       |    :heavy_check_mark:    |
 
 ## Supported commands

--- a/textfsm_aos/templates/ale_aos8_show_vlan_members.textfsm
+++ b/textfsm_aos/templates/ale_aos8_show_vlan_members.textfsm
@@ -1,6 +1,6 @@
 Value vlan (\d+)
 Value port ((\d{1,2}\/)+\d*)
-Value type (default|qtagged|dynamic|mirror|mirrored|spb|unpUntag|unpQntag)
+Value type (default|tagged|untagged|qtagged|dynamic|mirror|mirrored|spb|unpUntag|unpQntag)
 Value status (inactive|forwarding|blocking)
 
 Start


### PR DESCRIPTION
Fix integration test issue with show `vlan members` aos firmware 8.9.73.R01.  
Missing types values `tagged`and `untagged`.